### PR TITLE
Implement lyrics display and refactor track metadata initialization

### DIFF
--- a/app.qrc
+++ b/app.qrc
@@ -16,6 +16,7 @@
         <file>src/qml/Components/QueuePopup.qml</file>
         <file>src/qml/Components/AlbumArtPopup.qml</file>
         <file>src/qml/Components/QueueHeader.qml</file>
+        <file>src/qml/Components/LyricsView.qml</file>
         <file>src/qml/Views/LibraryPane.qml</file>
         <file>src/qml/Views/LibraryEditorWindow.qml</file>
         <file>src/qml/Views/SettingsWindow.qml</file>

--- a/src/backend/library/librarymanager.cpp
+++ b/src/backend/library/librarymanager.cpp
@@ -1868,9 +1868,9 @@ void LibraryManager::insertBatchTracksInThread(QSqlDatabase& db, const QList<QVa
     QSqlQuery trackInsert(db);
     trackInsert.prepare(
         "INSERT INTO tracks (file_path, title, artist_id, album_id, genre, year, "
-        "track_number, disc_number, duration, file_size, file_modified) "
+        "track_number, disc_number, duration, file_size, file_modified, lyrics) "
         "VALUES (:file_path, :title, :artist_id, :album_id, :genre, :year, "
-        ":track_number, :disc_number, :duration, :file_size, :file_modified)"
+        ":track_number, :disc_number, :duration, :file_size, :file_modified, :lyrics)"
     );
     
     // Process each track in the batch
@@ -1892,6 +1892,7 @@ void LibraryManager::insertBatchTracksInThread(QSqlDatabase& db, const QList<QVa
         int duration = metadata.value("duration").toInt();
         qint64 fileSize = metadata.value("fileSize", 0).toLongLong();
         QDateTime fileModified = metadata.value("fileModified").toDateTime();
+        QString lyrics = metadata.value("lyrics").toString();
         
         // Get or create artist (using cache)
         int artistId = getCachedArtist(artist);
@@ -1922,6 +1923,7 @@ void LibraryManager::insertBatchTracksInThread(QSqlDatabase& db, const QList<QVa
         trackInsert.bindValue(":duration", duration > 0 ? duration : QVariant());
         trackInsert.bindValue(":file_size", fileSize > 0 ? fileSize : QVariant());
         trackInsert.bindValue(":file_modified", fileModified.isValid() ? fileModified : QVariant());
+        trackInsert.bindValue(":lyrics", lyrics.isEmpty() ? QVariant() : lyrics);
         
         if (!trackInsert.exec()) {
             qWarning() << "Failed to insert track:" << filePath << "-" << trackInsert.lastError().text();

--- a/src/backend/library/track.cpp
+++ b/src/backend/library/track.cpp
@@ -71,6 +71,11 @@ QString Track::filePath() const
     return m_fileUrl.isLocalFile() ? m_fileUrl.toLocalFile() : m_fileUrl.toString();
 }
 
+QString Track::lyrics() const
+{
+    return m_lyrics;
+}
+
 // Property setters
 void Track::setTitle(const QString &title)
 {
@@ -153,6 +158,14 @@ void Track::setFileUrl(const QUrl &url)
     }
 }
 
+void Track::setLyrics(const QString &lyrics)
+{
+    if (m_lyrics != lyrics) {
+        m_lyrics = lyrics;
+        emit lyricsChanged();
+    }
+}
+
 // Additional methods
 QString Track::formattedDuration() const
 {
@@ -207,6 +220,9 @@ Track* Track::fromMetadata(const QVariantMap &metadata, QObject *parent)
         
     if (metadata.contains("duration"))
         track->setDuration(metadata.value("duration").toInt());
+
+    if (metadata.contains("lyrics"))
+        track->setLyrics(metadata.value("lyrics").toString());
     
     return track;
 }

--- a/src/backend/library/track.h
+++ b/src/backend/library/track.h
@@ -22,6 +22,7 @@ class Track : public QObject
     Q_PROPERTY(int duration READ duration WRITE setDuration NOTIFY durationChanged)
     Q_PROPERTY(QUrl fileUrl READ fileUrl WRITE setFileUrl NOTIFY fileUrlChanged)
     Q_PROPERTY(QString filePath READ filePath NOTIFY filePathChanged)
+    Q_PROPERTY(QString lyrics READ lyrics WRITE setLyrics NOTIFY lyricsChanged)
 
 public:
     explicit Track(QObject *parent = nullptr);
@@ -39,6 +40,7 @@ public:
     int duration() const; // in seconds
     QUrl fileUrl() const;
     QString filePath() const;
+    QString lyrics() const;
     
     // Property setters
     void setTitle(const QString &title);
@@ -51,6 +53,7 @@ public:
     void setDiscNumber(int discNumber);
     void setDuration(int duration);
     void setFileUrl(const QUrl &url);
+    void setLyrics(const QString &lyrics);
     
     // Additional methods
     Q_INVOKABLE QString formattedDuration() const; // Returns MM:SS format
@@ -71,6 +74,7 @@ signals:
     void durationChanged();
     void fileUrlChanged();
     void filePathChanged();
+    void lyricsChanged();
     
 private:
     QString m_title;
@@ -83,6 +87,7 @@ private:
     int m_discNumber = 0;
     int m_duration = 0; // in seconds
     QUrl m_fileUrl;
+    QString m_lyrics;
 };
 
 } // namespace Mtoc

--- a/src/backend/playback/mediaplayer.h
+++ b/src/backend/playback/mediaplayer.h
@@ -43,6 +43,7 @@ class MediaPlayer : public QObject
     Q_PROPERTY(QString currentPlaylistName READ currentPlaylistName NOTIFY currentPlaylistNameChanged)
     Q_PROPERTY(QString queueSourceAlbumName READ queueSourceAlbumName NOTIFY queueSourceAlbumNameChanged)
     Q_PROPERTY(QString queueSourceAlbumArtist READ queueSourceAlbumArtist NOTIFY queueSourceAlbumArtistChanged)
+    Q_PROPERTY(QString currentTrackLyrics READ currentTrackLyrics NOTIFY currentTrackLyricsChanged)
 
 public:
     enum State {
@@ -82,6 +83,7 @@ public:
     QString currentPlaylistName() const { return m_currentPlaylistName; }
     QString queueSourceAlbumName() const { return m_queueSourceAlbumName; }
     QString queueSourceAlbumArtist() const { return m_queueSourceAlbumArtist; }
+    QString currentTrackLyrics() const;
 
 public slots:
     void play();
@@ -147,6 +149,7 @@ signals:
     void currentPlaylistNameChanged(const QString& name);
     void queueSourceAlbumNameChanged(const QString& name);
     void queueSourceAlbumArtistChanged(const QString& artist);
+    void currentTrackLyricsChanged();
 
 private slots:
     void periodicStateSave();

--- a/src/backend/utility/metadataextractor.h
+++ b/src/backend/utility/metadataextractor.h
@@ -28,6 +28,7 @@ public:
         int trackNumber = 0;
         int discNumber = 0;
         int duration = 0; // in seconds
+        QString lyrics;
         // Album art data
         QByteArray albumArtData;
         QString albumArtMimeType;

--- a/src/qml/Components/LyricsView.qml
+++ b/src/qml/Components/LyricsView.qml
@@ -1,0 +1,23 @@
+import QtQuick
+import QtQuick.Controls
+import Mtoc.Backend 1.0
+
+ScrollView {
+    id: scrollView
+    width: parent.width
+    height: parent.height
+
+    property string lyricsText: ""
+
+    Label {
+        id: lyricsLabel
+        width: scrollView.width - 20
+        padding: 10
+        wrapMode: Text.WordWrap
+        font.pixelSize: 16
+        horizontalAlignment: Text.AlignHCenter
+
+        text: lyricsText.trim().length > 0 ? lyricsText : "No lyrics available for this track."
+        color: lyricsText.trim().length > 0 ? Theme.primaryText : Theme.secondaryText
+    }
+}

--- a/src/qml/Components/PlaybackControls.qml
+++ b/src/qml/Components/PlaybackControls.qml
@@ -19,10 +19,12 @@ Item {
     signal nextClicked()
     signal seekRequested(real position)
     signal queueToggled()
+    signal lyricsToggled()
     signal repeatToggled()
     signal shuffleToggled()
     
     property bool queueVisible: false
+    property bool lyricsVisible: false
     property bool repeatEnabled: MediaPlayer.repeatEnabled
     property bool shuffleEnabled: MediaPlayer.shuffleEnabled
     
@@ -227,25 +229,44 @@ Item {
             
             Item { Layout.fillWidth: true }
             
-            // Queue button container (matching repeat/shuffle width)
+            // Queue and Lyrics button container
             Item {
                 Layout.preferredWidth: 75
                 Layout.preferredHeight: 31
                 Layout.alignment: Qt.AlignVCenter
-                
-                // Queue button
-                IconButton {
-                    id: queueButton
-                    anchors.centerIn: parent
-                    width: 30
-                    height: 30
-                    iconSource: "qrc:/resources/icons/queue.svg"
-                    opacity: root.queueVisible ? 1.0 : 0.6
-                    addShadow: true
-                    onClicked: root.queueToggled()
-                    
-                    Behavior on opacity {
-                        NumberAnimation { duration: 200 }
+
+                RowLayout {
+                    anchors.fill: parent
+                    spacing: 10
+
+                    // Queue button
+                    IconButton {
+                        id: queueButton
+                        width: 30
+                        height: 30
+                        iconSource: "qrc:/resources/icons/queue.svg"
+                        opacity: root.queueVisible ? 1.0 : 0.6
+                        addShadow: true
+                        onClicked: root.queueToggled()
+                        
+                        Behavior on opacity {
+                            NumberAnimation { duration: 200 }
+                        }
+                    }
+
+                    // Lyrics button
+                    IconButton {
+                        id: lyricsButton
+                        width: 30
+                        height: 30
+                        iconSource: "qrc:/resources/icons/info.svg" // Replace with a proper lyrics icon if available
+                        opacity: root.lyricsVisible ? 1.0 : 0.6
+                        addShadow: true
+                        onClicked: root.lyricsToggled()
+
+                        Behavior on opacity {
+                            NumberAnimation { duration: 200 }
+                        }
                     }
                 }
             }

--- a/src/qml/Views/NowPlayingPane.qml
+++ b/src/qml/Views/NowPlayingPane.qml
@@ -16,6 +16,7 @@ Item {
     property var uniqueAlbumCovers: []
     property bool showPlaylistSavedMessage: false
     property string savedPlaylistName: ""
+    property bool lyricsVisible: false
     
     // Keyboard shortcut for undo
     Keys.onPressed: function(event) {
@@ -176,238 +177,247 @@ Item {
         visible: LibraryManager.trackCount > 0
         
         // Album art and queue container
-        Item {
+        StackLayout {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            
-            // Use manual positioning instead of RowLayout to avoid layout jumps
+            currentIndex: root.lyricsVisible ? 1 : 0
+
             Item {
-                anchors.fill: parent
-                
-                // Album art container
+                id: albumArtAndQueueContainer
+
+                // Use manual positioning instead of RowLayout to avoid layout jumps
                 Item {
-                    id: albumArtContainer
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    width: queueVisible ? parent.width * 0.24 : parent.width * 0.9
+                    anchors.fill: parent
                     
-                    // Calculate target width for proper x position calculation
-                    property real targetWidth: queueVisible ? parent.width * 0.24 : parent.width * 0.9
-                    
-                    // Position based on queue visibility - centered when hidden, left-aligned when visible
-                    // Use targetWidth instead of current width to ensure smooth simultaneous animation
-                    x: queueVisible ? 0 : (parent.width - targetWidth) / 2
-                    
-                    Behavior on width {
-                        NumberAnimation { 
-                            duration: 300
-                            easing.type: Easing.InOutCubic
-                        }
-                    }
-                    
-                    Behavior on x {
-                        NumberAnimation { 
-                            duration: 300
-                            easing.type: Easing.InOutCubic
-                        }
-                    }
-                    
-                    // Column to show multiple album covers when queue is visible
-                    Column {
-                        anchors.verticalCenter: parent.verticalCenter
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        width: parent.width
-                        height: parent.height
-                        spacing: queueVisible ? 10 : 0
-                        opacity: (queueVisible && uniqueAlbumCovers.length > 0) ? 1.0 : 0.0
-                        visible: opacity > 0
+                    // Album art container
+                    Item {
+                        id: albumArtContainer
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        width: queueVisible ? parent.width * 0.24 : parent.width * 0.9
                         
-                        Behavior on spacing {
-                            NumberAnimation {
+                        // Calculate target width for proper x position calculation
+                        property real targetWidth: queueVisible ? parent.width * 0.24 : parent.width * 0.9
+                        
+                        // Position based on queue visibility - centered when hidden, left-aligned when visible
+                        // Use targetWidth instead of current width to ensure smooth simultaneous animation
+                        x: queueVisible ? 0 : (parent.width - targetWidth) / 2
+                        
+                        Behavior on width {
+                            NumberAnimation { 
                                 duration: 300
                                 easing.type: Easing.InOutCubic
                             }
                         }
                         
-                        Behavior on opacity {
-                            NumberAnimation {
+                        Behavior on x {
+                            NumberAnimation { 
                                 duration: 300
                                 easing.type: Easing.InOutCubic
                             }
                         }
                         
-                        Repeater {
-                            model: uniqueAlbumCovers
+                        // Column to show multiple album covers when queue is visible
+                        Column {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            width: parent.width
+                            height: parent.height
+                            spacing: queueVisible ? 10 : 0
+                            opacity: (queueVisible && uniqueAlbumCovers.length > 0) ? 1.0 : 0.0
+                            visible: opacity > 0
                             
-                            Image {
-                                width: parent.width
-                                height: (parent.height - (parent.spacing * (uniqueAlbumCovers.length - 1))) / uniqueAlbumCovers.length
-                                source: {
-                                    if (modelData.albumArtist && modelData.album) {
-                                        var encodedArtist = encodeURIComponent(modelData.albumArtist)
-                                        var encodedAlbum = encodeURIComponent(modelData.album)
-                                        return "image://albumart/" + encodedArtist + "/" + encodedAlbum + "/full"
+                            Behavior on spacing {
+                                NumberAnimation {
+                                    duration: 300
+                                    easing.type: Easing.InOutCubic
+                                }
+                            }
+                            
+                            Behavior on opacity {
+                                NumberAnimation {
+                                    duration: 300
+                                    easing.type: Easing.InOutCubic
+                                }
+                            }
+                            
+                            Repeater {
+                                model: uniqueAlbumCovers
+                                
+                                Image {
+                                    width: parent.width
+                                    height: (parent.height - (parent.spacing * (uniqueAlbumCovers.length - 1))) / uniqueAlbumCovers.length
+                                    source: {
+                                        if (modelData.albumArtist && modelData.album) {
+                                            var encodedArtist = encodeURIComponent(modelData.albumArtist)
+                                            var encodedAlbum = encodeURIComponent(modelData.album)
+                                            return "image://albumart/" + encodedArtist + "/" + encodedAlbum + "/full"
+                                        }
+                                        return ""
                                     }
-                                    return ""
-                                }
-                                fillMode: Image.PreserveAspectFit
-                                cache: true
-                                
-                                // Drop shadow effect using MultiEffect
-                                layer.enabled: true
-                                layer.effect: MultiEffect {
-                                    shadowEnabled: true
-                                    shadowHorizontalOffset: 0
-                                    shadowVerticalOffset: 4
-                                    shadowBlur: 0.5
-                                    shadowColor: "#80000000"
-                                }
-                                
-                                // Placeholder when no album art
-                                Rectangle {
-                                    anchors.fill: parent
-                                    color: Theme.panelBackground
-                                    visible: parent.status !== Image.Ready || parent.source == ""
+                                    fillMode: Image.PreserveAspectFit
+                                    cache: true
                                     
-                                    Text {
-                                        anchors.centerIn: parent
-                                        text: "♪"
-                                        font.pixelSize: parent.width * 0.3
-                                        color: Theme.inputBackgroundHover
+                                    // Drop shadow effect using MultiEffect
+                                    layer.enabled: true
+                                    layer.effect: MultiEffect {
+                                        shadowEnabled: true
+                                        shadowHorizontalOffset: 0
+                                        shadowVerticalOffset: 4
+                                        shadowBlur: 0.5
+                                        shadowColor: "#80000000"
+                                    }
+                                    
+                                    // Placeholder when no album art
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        color: Theme.panelBackground
+                                        visible: parent.status !== Image.Ready || parent.source == ""
+                                        
+                                        Text {
+                                            anchors.centerIn: parent
+                                            text: "♪"
+                                            font.pixelSize: parent.width * 0.3
+                                            color: Theme.inputBackgroundHover
+                                        }
+                                    }
+                                    
+                                    // MouseArea to toggle queue on click
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: {
+                                            root.queueVisible = false
+                                        }
                                     }
                                 }
+                            }
+                        }
+                        
+                        // Single album art when queue is hidden
+                        Image {
+                            id: albumArt
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            width: parent.width
+                            height: parent.height
+                            source: albumArtUrl
+                            fillMode: Image.PreserveAspectFit
+                            cache: true
+                            opacity: (!queueVisible || uniqueAlbumCovers.length === 0) ? 1.0 : 0.0
+                            visible: opacity > 0
+                            
+                            Behavior on opacity {
+                                NumberAnimation {
+                                    duration: 300
+                                    easing.type: Easing.InOutCubic
+                                }
+                            }
+                            
+                            // Drop shadow effect using MultiEffect
+                            layer.enabled: true
+                            layer.effect: MultiEffect {
+                                shadowEnabled: true
+                                shadowHorizontalOffset: 0
+                                shadowVerticalOffset: 4
+                                shadowBlur: 0.5
+                                shadowColor: "#80000000"
+                            }
+                            
+                            // Placeholder when no album art
+                            Rectangle {
+                                anchors.fill: parent
+                                color: Theme.panelBackground
+                                visible: albumArt.status !== Image.Ready || !albumArtUrl
                                 
-                                // MouseArea to toggle queue on click
-                                MouseArea {
-                                    anchors.fill: parent
-                                    cursorShape: Qt.PointingHandCursor
-                                    onClicked: {
-                                        root.queueVisible = false
-                                    }
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: "♪"
+                                    font.pixelSize: parent.width * 0.3
+                                    color: Theme.inputBackgroundHover
                                 }
                             }
                         }
                     }
                     
-                    // Single album art when queue is hidden
-                    Image {
-                        id: albumArt
-                        anchors.verticalCenter: parent.verticalCenter
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        width: parent.width
-                        height: parent.height
-                        source: albumArtUrl
-                        fillMode: Image.PreserveAspectFit
-                        cache: true
-                        opacity: (!queueVisible || uniqueAlbumCovers.length === 0) ? 1.0 : 0.0
-                        visible: opacity > 0
+                    // Queue list view
+                    Item {
+                        id: queueContainer
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        width: queueVisible ? parent.width * 0.7 - 16 : 0
+                        opacity: queueVisible ? 1.0 : 0.0
+                        visible: opacity > 0 || width > 1  // Stay visible during animations
+                        clip: true
                         
-                        Behavior on opacity {
-                            NumberAnimation {
+                        Behavior on width {
+                            NumberAnimation { 
                                 duration: 300
                                 easing.type: Easing.InOutCubic
                             }
                         }
                         
-                        // Drop shadow effect using MultiEffect
-                        layer.enabled: true
-                        layer.effect: MultiEffect {
-                            shadowEnabled: true
-                            shadowHorizontalOffset: 0
-                            shadowVerticalOffset: 4
-                            shadowBlur: 0.5
-                            shadowColor: "#80000000"
+                        Behavior on opacity {
+                            NumberAnimation { 
+                                duration: 300
+                                easing.type: Easing.InOutCubic
+                            }
                         }
                         
-                        // Placeholder when no album art
                         Rectangle {
                             anchors.fill: parent
-                            color: Theme.panelBackground
-                            visible: albumArt.status !== Image.Ready || !albumArtUrl
+                            color: Qt.rgba(0, 0, 0, 0.3)
+                            radius: 8
+                            border.width: 1
+                            border.color: Qt.rgba(1, 1, 1, 0.1)
                             
-                            Text {
-                                anchors.centerIn: parent
-                                text: "♪"
-                                font.pixelSize: parent.width * 0.3
-                                color: Theme.inputBackgroundHover
+                            ColumnLayout {
+                                anchors.fill: parent
+                                anchors.margins: 12
+                                spacing: 8
+                            
+                            // Queue header
+                            QueueHeader {
+                                Layout.fillWidth: true
+                                showPlaylistSavedMessage: root.showPlaylistSavedMessage
+                                forceLightText: true // Always use light text on dark background
+                                
+                                onClearQueueRequested: {
+                                    queueListView.clearAllTracks();
+                                }
                             }
+                            
+                            // Queue list
+                            QueueListView {
+                                id: queueListView
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                queueModel: MediaPlayer.queue
+                                currentPlayingIndex: MediaPlayer.currentQueueIndex
+                                focus: root.queueVisible
+                                forceLightText: true // Always use light text on dark background
+                                
+                                onTrackDoubleClicked: function(index) {
+                                    MediaPlayer.playTrackAt(index);
+                                }
+                                
+                                onRemoveTrackRequested: function(index) {
+                                    MediaPlayer.removeTrackAt(index);
+                                }
+                                
+                                onRemoveTracksRequested: function(indices) {
+                                    MediaPlayer.removeTracks(indices);
+                                }
+                            }
+                        }
                         }
                     }
                 }
-                
-                // Queue list view
-                Item {
-                    id: queueContainer
-                    anchors.right: parent.right
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    width: queueVisible ? parent.width * 0.7 - 16 : 0
-                    opacity: queueVisible ? 1.0 : 0.0
-                    visible: opacity > 0 || width > 1  // Stay visible during animations
-                    clip: true
-                    
-                    Behavior on width {
-                        NumberAnimation { 
-                            duration: 300
-                            easing.type: Easing.InOutCubic
-                        }
-                    }
-                    
-                    Behavior on opacity {
-                        NumberAnimation { 
-                            duration: 300
-                            easing.type: Easing.InOutCubic
-                        }
-                    }
-                    
-                    Rectangle {
-                        anchors.fill: parent
-                        color: Qt.rgba(0, 0, 0, 0.3)
-                        radius: 8
-                        border.width: 1
-                        border.color: Qt.rgba(1, 1, 1, 0.1)
-                        
-                        ColumnLayout {
-                            anchors.fill: parent
-                            anchors.margins: 12
-                            spacing: 8
-                        
-                        // Queue header
-                        QueueHeader {
-                            Layout.fillWidth: true
-                            showPlaylistSavedMessage: root.showPlaylistSavedMessage
-                            forceLightText: true // Always use light text on dark background
-                            
-                            onClearQueueRequested: {
-                                queueListView.clearAllTracks();
-                            }
-                        }
-                        
-                        // Queue list
-                        QueueListView {
-                            id: queueListView
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            queueModel: MediaPlayer.queue
-                            currentPlayingIndex: MediaPlayer.currentQueueIndex
-                            focus: root.queueVisible
-                            forceLightText: true // Always use light text on dark background
-                            
-                            onTrackDoubleClicked: function(index) {
-                                MediaPlayer.playTrackAt(index);
-                            }
-                            
-                            onRemoveTrackRequested: function(index) {
-                                MediaPlayer.removeTrackAt(index);
-                            }
-                            
-                            onRemoveTracksRequested: function(indices) {
-                                MediaPlayer.removeTracks(indices);
-                            }
-                        }
-                    }
-                    }
-                }
+            }
+
+            LyricsView {
+                lyricsText: MediaPlayer.currentTrackLyrics
             }
         }
         
@@ -536,6 +546,7 @@ Item {
             Layout.preferredHeight: 80
             
             queueVisible: root.queueVisible
+            lyricsVisible: root.lyricsVisible
             
             onPlayPauseClicked: MediaPlayer.togglePlayPause()
             onPreviousClicked: MediaPlayer.previous()
@@ -544,6 +555,7 @@ Item {
                 MediaPlayer.seek(position)
             }
             onQueueToggled: root.queueVisible = !root.queueVisible
+            onLyricsToggled: root.lyricsVisible = !root.lyricsVisible
             onRepeatToggled: {
                 MediaPlayer.repeatEnabled = !MediaPlayer.repeatEnabled
             }


### PR DESCRIPTION
This commit introduces the ability to display unsynced lyrics for tracks and also refactors how track objects are initialized in metadataextractor.cpp

Lyrics:
    - Add `LyricsView.qml` for displaying lyrics.
    - Integrate `LyricsView` into `NowPlayingPane.qml` with a toggle button in `PlaybackControls.qml`.
    - Extend `Track` class (`track.h`, `track.cpp`) with a `lyrics` property.
    - Update `MediaPlayer` (`mediaplayer.h`, `mediaplayer.cpp`) to expose `currentTrackLyrics`.
    - Modify `DatabaseManager` (`databasemanager.cpp`) to store and retrieve lyrics in the `tracks` table.
    - Update `MetadataExtractor` (`metadataextractor.h`, `metadataextractor.cpp`) to extract unsynced lyrics from various audio file formats (ID3v2 USLT, Xiph `LYRICS`).

Refactor:
Replace manual `Mtoc::Track` object instantiation and property setting with `Mtoc::Track::fromMetadata(trackMap, this)`.
Affected functions include:
    - `playPlaylist`
    - `playTrackFromData`
    - `playAlbumNext`
    - `playAlbumLast`
    - `playPlaylistNext`
    - `playPlaylistLast`
    - `restoreState`
    - `restoreTrackFromData`
    - `loadVirtualPlaylistNext`
    - `loadVirtualPlaylistLast`