### PR TITLE
Wire up the new lyrics icons and add explicit handling for m4a lyrics

### DIFF
--- a/app.qrc
+++ b/app.qrc
@@ -74,6 +74,8 @@
         <file>resources/icons/list-drag-handle-dark.svg</file>
         <file>resources/icons/info.svg</file>
         <file>resources/icons/info-dark.svg</file>
+        <file>resources/icons/lyrics-icon.svg</file>
+        <file>resources/icons/lyrics-icon-dark.svg</file>
         <file>resources/icons/minimize.svg</file>
         <file>resources/icons/minimize-dark.svg</file>
         <file>resources/icons/maximize.svg</file>

--- a/src/backend/utility/metadataextractor.cpp
+++ b/src/backend/utility/metadataextractor.cpp
@@ -384,8 +384,21 @@ MetadataExtractor::TrackMetadata MetadataExtractor::extract(const QString &fileP
                 meta.albumArtist = meta.artist;
             }
 
-            
-            
+            // Lyrics
+            meta.lyrics = getStringValue("©lyr");
+            if (meta.lyrics.isEmpty()) {
+                try {
+                    TagLib::StringList lyricsList = properties.value("LYRICS");
+                    if (!lyricsList.isEmpty() && lyricsList.size() > 0) {
+                        meta.lyrics = QString::fromStdString(lyricsList.front().to8Bit(true));
+                    }
+                } catch (const std::exception& e) {
+                    qDebug() << "MetadataExtractor: Exception accessing LYRICS property:" << e.what();
+                } catch (...) {
+                    qDebug() << "MetadataExtractor: Failed to access LYRICS property";
+                }
+            }
+
             // Audio properties from the MP4 file
             if (mp4File.audioProperties()) {
                 meta.duration = mp4File.audioProperties()->lengthInSeconds();

--- a/src/qml/Components/PlaybackControls.qml
+++ b/src/qml/Components/PlaybackControls.qml
@@ -259,7 +259,7 @@ Item {
                         id: lyricsButton
                         width: 30
                         height: 30
-                        iconSource: "qrc:/resources/icons/info.svg" // Replace with a proper lyrics icon if available
+                        iconSource: Theme.isDark ? "qrc:/resources/icons/lyrics-icon.svg" : "qrc:/resources/icons/lyrics-icon-dark.svg"
                         opacity: root.lyricsVisible ? 1.0 : 0.6
                         addShadow: true
                         onClicked: root.lyricsToggled()


### PR DESCRIPTION
- Add the new lyrics icons (dark and light) to `src/qml/Components/PlaybackControls.qml`
- Handle lyrics tag in M4A like how other tags are handled (for example `meta.title = getStringValue("©nam");`)
  - This looks for the "©lyr" tag (or "\xa9lyr") ([mutagen docs](https://mutagen.readthedocs.io/en/latest/api/mp4.html#mutagen.mp4.MP4Tags))
  - like all the other tags in the function, if it doesn't find it, it falls back to the TagLib PropertyMap and looks for "LYRICS"