### PR TITLE
Add support for synchronized lyrics and sidecar (lrc) files

### DIFF
--- a/src/backend/utility/metadataextractor.h
+++ b/src/backend/utility/metadataextractor.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QString>
 #include <QVariantMap>
+#include <QMap>
 
 // TagLib forward declarations (prefer includes in .cpp if possible to reduce compile times)
 // However, for Fileref, it's common to include directly.
@@ -53,6 +54,8 @@ public:
     Q_INVOKABLE QByteArray extractAlbumArt(const QString &filePath);
     Q_INVOKABLE bool hasAlbumArt(const QString &filePath);
 
+private:
+    std::pair<QString, QMap<qint64, QString>> parseLrcFile(const QString &lrcFilePath);
 };
 
 } // namespace Mtoc

--- a/src/qml/Components/LyricsView.qml
+++ b/src/qml/Components/LyricsView.qml
@@ -2,22 +2,122 @@ import QtQuick
 import QtQuick.Controls
 import Mtoc.Backend 1.0
 
-ScrollView {
-    id: scrollView
-    width: parent.width
-    height: parent.height
+Item {
+    id: root
 
     property string lyricsText: ""
 
-    Label {
-        id: lyricsLabel
-        width: scrollView.width - 20
-        padding: 10
-        wrapMode: Text.WordWrap
-        font.pixelSize: 16
-        horizontalAlignment: Text.AlignHCenter
+    property var lyricsModel: []
+    property int currentLineIndex: -1
 
-        text: lyricsText.trim().length > 0 ? lyricsText : "No lyrics available for this track."
-        color: lyricsText.trim().length > 0 ? Theme.primaryText : Theme.secondaryText
+    // Timer to avoid spamming index updates
+    Timer {
+        id: updateTimer
+        interval: 100 // Check 10 times per second
+        running: root.lyricsModel.length > 0 && lyricsModel[0].time >= 0 && MediaPlayer.state === MediaPlayer.PlayingState
+        repeat: true
+        onTriggered: root.updateCurrentLineIndex(MediaPlayer.position)
+    }
+
+    onLyricsTextChanged: {
+        parseLyrics()
+    }
+
+    function parseLyrics() {
+        currentLineIndex = -1
+        lyricsModel = []
+
+        if (!lyricsText) {
+            return;
+        }
+
+        var trimmedText = lyricsText.trim()
+        // Simple heuristic to check for our JSON format
+        if (trimmedText.startsWith('[') && trimmedText.endsWith(']')) {
+            try {
+                var parsed = JSON.parse(trimmedText)
+                if (parsed && parsed.length > 0) {
+                    lyricsModel = parsed
+                    return // Success, we have a synchronized model
+                }
+            } catch (e) {
+                // It looked like JSON but wasn't. Fall through to treat as plain text.
+                console.error("LyricsView: Failed to parse lyrics as JSON, falling back to plain text.", e)
+            }
+        }
+
+        // Fallback for plain text (or failed JSON parse)
+        lyricsModel = trimmedText.split('\n').map(function(line) {
+            return { time: -1, text: line };
+        });
+    }
+
+    function updateCurrentLineIndex(position) {
+        if (lyricsModel.length === 0 || lyricsModel[0].time < 0) {
+            currentLineIndex = -1
+            return // Not synchronized
+        }
+
+        var newIndex = -1;
+        for (var i = 0; i < lyricsModel.length; i++) {
+            if (position >= lyricsModel[i].time) {
+                newIndex = i;
+            } else {
+                break; // Timestamps are sorted
+            }
+        }
+
+        if (newIndex !== -1 && newIndex !== currentLineIndex) {
+            currentLineIndex = newIndex
+            lyricsListView.positionViewAtIndex(currentLineIndex, ListView.Center)
+        }
+    }
+
+    ListView {
+        id: lyricsListView
+        anchors.fill: parent
+        model: lyricsModel
+        clip: true
+        spacing: 12
+        
+        // Add some padding at the top and bottom to center the text better
+        topMargin: height / 2.5
+        bottomMargin: height / 2
+
+        delegate: Item {
+            width: lyricsListView.width
+            height: lyricText.height
+
+            Text {
+                id: lyricText
+                width: parent.width - 40 // Add some horizontal padding
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: modelData.text
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: 20
+                color: Theme.primaryText
+
+                // Set opacity and font style for the current line
+                opacity: index === root.currentLineIndex ? 1.0 : 0.6
+                font.bold: index === root.currentLineIndex
+
+                Behavior on opacity { NumberAnimation { duration: 200 } }
+            }
+        }
+
+        // Placeholder for when there are no lyrics
+        Rectangle {
+            anchors.fill: parent
+            color: "transparent"
+            visible: !lyricsText
+
+            Label {
+                anchors.centerIn: parent
+                text: "No lyrics available for this track."
+                font.pixelSize: 16
+                color: Theme.secondaryText
+            }
+        }
     }
 }


### PR DESCRIPTION
This commit introduces support for reading lyrics from sidecar LRC files.
Lyrics from LRC files are given higher precedence than embedded lyrics as they can be easily modified or removed by the user if they wish to do so. In other words, if a file has both LRC and embedded lyrics, the LRC file will be given higher precedence.

This commit also adds support for LRC Synchronized Lyrics. This is done by parsing timed text lyrics from lrc files into a json based format and storing it in the existing lyrics property of the track.
The frontend reads this lyrics property and uses a simple heuristic to detect whether it is json or just plain text and renders the lyrics accordingly.

Currently, synchronized lyrics are only supported for sidecar LRC files as that is the de-facto standard for timed lyrics. The other popular standard is the MP3 ID3 SYLT frame which is specific to mp3 files. This can be taken up in the future.