### PR TITLE
Add support for SYLT synchronized lyrics for MP3 files

### DIFF
--- a/src/backend/utility/metadataextractor.h
+++ b/src/backend/utility/metadataextractor.h
@@ -10,6 +10,8 @@
 // However, for Fileref, it's common to include directly.
 #include <taglib/fileref.h>
 #include <taglib/tag.h>
+#include <taglib/id3v2frame.h>
+#include <taglib/synchronizedlyricsframe.h>
 
 namespace Mtoc {
 
@@ -56,6 +58,7 @@ public:
 
 private:
     std::pair<QString, QMap<qint64, QString>> parseLrcFile(const QString &lrcFilePath);
+    QMap<qint64, QString> parseSyltFrame(const TagLib::ID3v2::SynchronizedLyricsFrame *frame);
 };
 
 } // namespace Mtoc


### PR DESCRIPTION
This leverages TagLib's SYLT parsing to read synchronized lyrics from MP3 and then we save that to our internal json format just like how LRC synced lyrics are handled.