### PR TITLE
Enable seeking on clicking synced lyric lines

### DIFF
--- a/src/qml/Components/LyricsView.qml
+++ b/src/qml/Components/LyricsView.qml
@@ -84,9 +84,18 @@ Item {
         topMargin: height / 2.5
         bottomMargin: height / 2
 
-        delegate: Item {
+        delegate: MouseArea {
             width: lyricsListView.width
             height: lyricText.height
+
+            // For synced lyrics, change cursor and allow seeking
+            cursorShape: modelData.time >= 0 ? Qt.PointingHandCursor : Qt.ArrowCursor
+
+            onClicked: {
+                if (modelData.time >= 0) {
+                    MediaPlayer.seek(modelData.time)
+                }
+            }
 
             Text {
                 id: lyricText


### PR DESCRIPTION
When viewing synchronized lyrics, clicking on any line will seek the media player's position to that line's specific timestamp.